### PR TITLE
fixed promised type.

### DIFF
--- a/src/com/activeandroid/serializer/CalendarSerializer.java
+++ b/src/com/activeandroid/serializer/CalendarSerializer.java
@@ -24,7 +24,7 @@ public final class CalendarSerializer extends TypeSerializer {
 	}
 
 	public Class<?> getSerializedType() {
-		return long.class;
+		return Long.class;
 	}
 
 	public Long serialize(Object data) {


### PR DESCRIPTION
The class promised a long.class as returned serialised value, but returned Long.class, giving a lot of  TypeSerializer returned wrong type: expected a long but got a class java.lang.Long in the log.